### PR TITLE
Encyclopedic citations and font issue

### DIFF
--- a/trkut.cbx
+++ b/trkut.cbx
@@ -30,11 +30,9 @@
   \iffieldundef{shorthand}
     {\ifthenelse{\ifciteibid\AND\NOT\iffirstonpage}
        {\usebibmacro{cite:ibid}}%
-       {\StrLeft{\strfield{labeltitle}}{4}[\maybesv]%
+       {\StrLeft{\strfield{labeltitle}}{14}[\maybesv]%
        % TODO HACK: detects A.A. as s.v. where A is any letter
-       \StrPosition{\maybesv}{.}[\kaks]%
-       \StrPosition[2]{\maybesv}{.}[\neli]%
-        \IfStrEq{\kaks\neli}{24}
+        \IfStrEq{\maybesv}{\detokenize{\textit{s.v.}}}
          {\printnames{labelname}
          \setunit{\nameyeardelim}%
          \ifthenelse{\ifnameundef{year}}{\printfield{urlyear}}{\printfield{year}}%

--- a/trkut.cls
+++ b/trkut.cls
@@ -14,7 +14,6 @@
 \LoadClass[oneside, 12pt, headings=small, numbers=noendperiod]{scrreprt}% Numbrite vahel ja lõpus on punkt, chapter font large, 12pt.
 
 \RequirePackage{etoolbox}% Scriptimismacrod
-\RequirePackage{lmodern}%
 \RequirePackage{polyglossia}% Eesti keele tugi
 \setdefaultlanguage{estonian}
 \RequirePackage{csquotes}% Eesti jutumärgid käsuga \enquote{}


### PR DESCRIPTION
Content should be obvious enough. For reference, the way to use s.v. in citations is to put "\textit{s.v.}" in the 'title' field for whatever is being cited in the corresponding .bib file.